### PR TITLE
Enable tenant feature toggles for assigned users

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -1,7 +1,8 @@
 
 import json, hmac, hashlib
+from copy import deepcopy
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 SECRET = "supersecret"
 BASE_DIR = Path(__file__).resolve().parent
@@ -14,9 +15,15 @@ DEFAULTS = {
         "broadcasting": False,
         "leveling": False,
         "blackjack": False,
-        "assistants": False
-    }
+        "assistants": False,
+    },
 }
+
+
+def _fresh_defaults() -> dict:
+    base = deepcopy(DEFAULTS)
+    base["features"] = dict(DEFAULTS["features"])
+    return base
 
 def _signable(data: dict) -> bytes:
     d = dict(data)
@@ -40,23 +47,41 @@ def tenants() -> List[dict]:
     return t.get("tenants", [])
 
 def set_tenants(data: List[dict]):
-    _write_json(TENANTS_PATH, {"tenants": data})
+    payload = _read_json(TENANTS_PATH)
+    payload["tenants"] = data
+    _write_json(TENANTS_PATH, payload)
+
+    mirror = payload.get("mirror_path")
+    if mirror:
+        try:
+            _write_json(Path(mirror), payload)
+        except Exception:
+            pass
+
+
+def tenant_for_user(user_id: int, username: Optional[str] = None) -> Optional[dict]:
+    uname = (username or "").lstrip("@").lower()
+    for tenant in tenants():
+        mapped_id = tenant.get("tg_user_id")
+        if mapped_id is not None and str(mapped_id) == str(user_id):
+            return tenant
+        mapped_username = tenant.get("tg_username")
+        if mapped_username and uname and mapped_username.lower().lstrip("@") == uname:
+            return tenant
+    return None
 
 def ensure_config_for(tenant_id: str) -> dict:
     cfg_path = CONFIGS_DIR / f"{tenant_id}.json"
     if not cfg_path.exists():
-        data = dict(DEFAULTS)
-        _sign_inplace(data)
-        _write_json(cfg_path, data)
-        return data
+        state = _fresh_defaults()
+        return _persist_config(tenant_id, state)
+
     data = _read_json(cfg_path)
     # normalize keys (in case of missing fields)
-    base = dict(DEFAULTS)
-    base["features"].update(data.get("features", {}))
-    base["version"] = data.get("version", 1)
-    _sign_inplace(base)
-    _write_json(cfg_path, base)
-    return base
+    state = _fresh_defaults()
+    state["features"].update({k: bool(v) for k, v in data.get("features", {}).items()})
+    state["version"] = int(data.get("version", state["version"]))
+    return _persist_config(tenant_id, state)
 
 def _write_to_target_if_any(tenant_id: str, data: dict):
     # if tenant mapping has a config_path, write there as well
@@ -71,16 +96,28 @@ def _write_to_target_if_any(tenant_id: str, data: dict):
                     pass
             break
 
-def toggle(tenant_id: str, feature_id: str) -> dict:
-    state = ensure_config_for(tenant_id)
-    feats: Dict[str, bool] = state["features"]
-    if feature_id not in feats:
-        feats[feature_id] = False
-    feats[feature_id] = not feats[feature_id]
-    state["version"] = int(state.get("version", 1)) + 1
+
+def _persist_config(tenant_id: str, state: dict) -> dict:
     _sign_inplace(state)
-    # write to local configs/<tenant>.json
     _write_json(CONFIGS_DIR / f"{tenant_id}.json", state)
-    # also mirror to target config.json if configured
     _write_to_target_if_any(tenant_id, state)
     return state
+
+def toggle(tenant_id: str, feature_id: str) -> dict:
+    state = ensure_config_for(tenant_id)
+    feats: Dict[str, bool] = state.setdefault("features", {})
+    current = bool(feats.get(feature_id, False))
+    feats[feature_id] = not current
+    state["version"] = int(state.get("version", 1)) + 1
+    return _persist_config(tenant_id, state)
+
+
+def set_feature(tenant_id: str, feature_id: str, enabled: bool) -> dict:
+    state = ensure_config_for(tenant_id)
+    feats: Dict[str, bool] = state.setdefault("features", {})
+    desired = bool(enabled)
+    if feats.get(feature_id, False) == desired:
+        return state
+    feats[feature_id] = desired
+    state["version"] = int(state.get("version", 1)) + 1
+    return _persist_config(tenant_id, state)

--- a/configs/tenants.json
+++ b/configs/tenants.json
@@ -1,9 +1,10 @@
 {
+  "mirror_path": "C:\\Users\\eriku\\Desktop\\Botai2025\\Projektas_Botas_Shopas\\Pilnas\\ParduotuvesBot\\configs\\tenants.json",
   "tenants": [
     {
       "id": "customer1",
       "name": "Customer 1",
-      "config_path": "C:\\Users\\eriku\\Desktop\\Botai2025\\Projektas_Botas_Shopas\\Pilnas\\Testas\\config.json"
+      "config_path": "C:\\Users\\eriku\\Desktop\\Botai2025\\Projektas_Botas_Shopas\\Pilnas\\ParduotuvesBot\\configs\\customer1.json"
     }
   ]
 }

--- a/keyboards.py
+++ b/keyboards.py
@@ -246,8 +246,8 @@ def admin_panel_keyboard(lang: str, online: bool):
     kb.add(InlineKeyboardButton(toggle, callback_data="admin:toggle_online"))
     kb.add(InlineKeyboardButton(T[lang]["user_lookup"], callback_data="admin:user_lookup"))
     kb.add(InlineKeyboardButton(T[lang]["manage_rdps"], callback_data="admin:rdps"))
-    kb.add(InlineKeyboardButton("Priskirti klientą", callback_data="admin:assign_customer"))
-    kb.add(InlineKeyboardButton("Funkcijos", callback_data="cfg:back"))
+    kb.add(InlineKeyboardButton("🤝 Priskirti klientą", callback_data="admin:assign_customer"))
+    kb.add(InlineKeyboardButton("🧩 Funkcijos", callback_data="cfg:back"))
     kb.add(InlineKeyboardButton(T[lang]["back"], callback_data="back"))
     return kb
 

--- a/main.py
+++ b/main.py
@@ -51,6 +51,7 @@ from keyboards import (
     admin_rdp_cancel_keyboard,
 )
 from aiogram.dispatcher import FSMContext
+from aiogram.dispatcher.filters import Command
 from aiogram.dispatcher.filters.state import State, StatesGroup
 from texts import T
 from payments import create_invoice, ipn_handler, init_payments
@@ -197,8 +198,21 @@ async def cb_config(call: types.CallbackQuery):
 async def cb_config_functions(call: types.CallbackQuery):
     lang = db.get_language(call.from_user.id)
     history[call.from_user.id].append((call.message.text or "", call.message.reply_markup))
+    tenant = cfg_tenant_for_user(call.from_user.id, call.from_user.username)
+
+    if tenant:
+        state = cfg_ensure(tenant["id"])
+        await call.message.edit_text(
+            T[lang]["functions_toggle_title"].format(
+                tenant=_tenant_display_name(tenant)
+            ),
+            reply_markup=_user_features_kb(lang, state, tenant["id"]),
+        )
+        return
+
     await call.message.edit_text(
-        T[lang]["functions_title"], reply_markup=functions_menu_keyboard(lang)
+        T[lang]["functions_toggle_not_assigned"],
+        reply_markup=functions_menu_keyboard(lang),
     )
 
 
@@ -1063,237 +1077,120 @@ if __name__ == "__main__":
 
 
 
-# === Feature Config Handlers (admin) ===
-from aiogram import types
-from aiogram.dispatcher.filters import Command
-from .config import ADMIN_ID
-from .config_manager import ensure_config, toggle as cfg_toggle
-
-FEATURES = [("broadcasting","Broadcasting"), ("leveling","Leveling"), ("blackjack","Blackjack"), ("assistants","Assistants")]
-
-def _features_kb(state: dict):
-    from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
-    kb = InlineKeyboardMarkup(row_width=1)
-    feats = state.get("features", {})
-    for fid, title in FEATURES:
-        val = "Enabled" if feats.get(fid, False) else "Disabled"
-        kb.add(InlineKeyboardButton(f"{title}: {val}", callback_data=f"cfg:toggle:{fid}"))
-    kb.add(InlineKeyboardButton("⬅️ Back", callback_data="cfg:back"))
-    return kb
-
-@dp.message_handler(Command("config"))
-async def cmd_config(message: types.Message):
-    if str(message.from_user.id) != str(ADMIN_ID):
-        return await message.answer("Config is admin-only.")
-    state = ensure_config()
-    await message.answer("⚙️ Feature Toggles", reply_markup=_features_kb(state))
-
-@dp.callback_query_handler(lambda c: c.data and c.data.startswith("cfg:toggle:"))
-async def cb_cfg_toggle(call: types.CallbackQuery):
-    if str(call.from_user.id) != str(ADMIN_ID):
-        return await call.answer("Not allowed.", show_alert=True)
-    fid = call.data.split(":", 2)[2]
-    state = cfg_toggle(fid)
-    await call.message.edit_reply_markup(reply_markup=_features_kb(state))
-    await call.answer("Toggled.")
-
-@dp.callback_query_handler(lambda c: c.data == "cfg:back")
-async def cb_cfg_back(call: types.CallbackQuery):
-    await call.message.delete()
-
-
-
-# === Multi-tenant Feature Config (admin) ===
-from aiogram import types
-from aiogram.dispatcher.filters import Command
-from .config import ADMIN_ID
-from .config_manager import tenants as cfg_tenants, ensure_config_for as cfg_ensure, toggle as cfg_toggle
-
-FEATURES = [("broadcasting","Broadcasting"), ("leveling","Leveling"), ("blackjack","Blackjack"), ("assistants","Assistants")]
-
-def _tenants_kb():
-    from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
-    kb = InlineKeyboardMarkup(row_width=1)
-    ts = cfg_tenants()
-    if not ts:
-        kb.add(InlineKeyboardButton("No tenants configured", callback_data="cfg:none"))
-    for t in ts:
-        label = f"🧑‍💼 {t.get('name','Unnamed')} ({t.get('id')})"
-        kb.add(InlineKeyboardButton(label, callback_data=f"cfg:tenant:{t.get('id')}"))
-    return kb
-
-def _features_kb(state: dict, tenant_id: str):
-    from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
-    kb = InlineKeyboardMarkup(row_width=1)
-    feats = state.get("features", {})
-    for fid, title in FEATURES:
-        val = "Enabled" if feats.get(fid, False) else "Disabled"
-        kb.add(InlineKeyboardButton(f"{title}: {val}", callback_data=f"cfg:toggle:{tenant_id}:{fid}"))
-    kb.add(InlineKeyboardButton("⬅️ Back", callback_data="cfg:back"))
-    return kb
-
-@dp.message_handler(Command("config"))
-async def cmd_config(message: types.Message):
-    if str(message.from_user.id) != str(ADMIN_ID):
-        return await message.answer("Config is admin-only.")
-    await message.answer("⚙️ Choose a tenant", reply_markup=_tenants_kb())
-
-@dp.callback_query_handler(lambda c: c.data and c.data.startswith("cfg:tenant:"))
-async def cb_cfg_tenant(call: types.CallbackQuery):
-    if str(call.from_user.id) != str(ADMIN_ID):
-        return await call.answer("Not allowed.", show_alert=True)
-    tenant_id = call.data.split(":", 2)[2]
-    state = cfg_ensure(tenant_id)
-    await call.message.edit_text(f"⚙️ Feature Toggles for {tenant_id}", reply_markup=_features_kb(state, tenant_id))
-
-@dp.callback_query_handler(lambda c: c.data and c.data.startswith("cfg:toggle:"))
-async def cb_cfg_toggle(call: types.CallbackQuery):
-    if str(call.from_user.id) != str(ADMIN_ID):
-        return await call.answer("Not allowed.", show_alert=True)
-    _, _, tenant_id, fid = call.data.split(":", 3)
-    state = cfg_toggle(tenant_id, fid)
-    await call.message.edit_reply_markup(reply_markup=_features_kb(state, tenant_id))
-    await call.answer("Toggled.")
-
-@dp.callback_query_handler(lambda c: c.data == "cfg:back")
-async def cb_cfg_back(call: types.CallbackQuery):
-    await call.message.edit_text("⚙️ Choose a tenant", reply_markup=_tenants_kb())
-
-
-
-# === Admin: Assign Customer to Telegram Username ===
-from aiogram.dispatcher import FSMContext
-from aiogram.dispatcher.filters.state import State, StatesGroup
-from .config_manager import tenants as cfg_tenants, set_tenants as cfg_set_tenants
-
-class AssignStates(StatesGroup):
-    waiting_for_mapping = State()
-
-@dp.callback_query_handler(lambda c: c.data == "admin:assign_customer")
-async def cb_admin_assign(call: types.CallbackQuery, state: FSMContext):
-    if str(call.from_user.id) != str(ADMIN_ID):
-        return await call.answer("Not allowed.", show_alert=True)
-    await state.set_state(AssignStates.waiting_for_mapping.state)
-    await call.message.edit_text("Send mapping in format:\n<tenant_id> | @username\nExample: customer1 | @john")
-
-@dp.message_handler(state=AssignStates.waiting_for_mapping)
-async def assign_mapping(message: types.Message, state: FSMContext):
-    if str(message.from_user.id) != str(ADMIN_ID):
-        return
-    text = message.text.strip()
-    if "|" not in text:
-        return await message.answer("Use format: tenant_id | @username")
-    tenant_id, username = [x.strip() for x in text.split("|",1)]
-    username = username.lstrip("@")
-    ts = cfg_tenants()
-    # find tenant or create new entry
-    found = False
-    for t in ts:
-        if t.get("id")==tenant_id:
-            t["tg_username"] = username
-            found = True
-            break
-    if not found:
-        ts.append({"id": tenant_id, "name": tenant_id, "tg_username": username, "config_path": ""})
-    cfg_set_tenants(ts)
-    await state.finish()
-    await message.answer(f"Mapped @{username} → {tenant_id} ✅")
-
-# === Functions Menu (same toggles UI) ===
-FEATURES = [("broadcasting","Broadcasting"), ("leveling","Leveling"), ("blackjack","Blackjack"), ("assistants","Assistants")]
-
-def _features_onoff_kb(state: dict, tenant_id: str):
-    from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
-    kb = InlineKeyboardMarkup(row_width=2)
-    feats = state.get("features", {})
-    for fid, title in FEATURES:
-        is_on = feats.get(fid, False)
-        kb.add(
-            InlineKeyboardButton(f"{title} · {'ON' if is_on else 'OFF'}", callback_data="cfg:none"),
-            InlineKeyboardButton("Turn Off" if is_on else "Turn On", callback_data=f"cfg:set:{tenant_id}:{fid}:{'off' if is_on else 'on'}")
-        )
-    kb.add(InlineKeyboardButton("⬅️ Back", callback_data="cfg:back"))
-    return kb
-
-@dp.callback_query_handler(lambda c: c.data == "menu:functions")
-async def cb_menu_functions(call: types.CallbackQuery):
-    if str(call.from_user.id) != str(ADMIN_ID):
-        return await call.answer("Admin-only.", show_alert=True)
-    # if username was assigned to a tenant, try to pick by username; else show tenant list
-    ts = cfg_tenants()
-    # Build a menu of tenants
-    await call.message.edit_text("⚙️ Choose a tenant for Functions", reply_markup=_tenants_kb())
-
-@dp.callback_query_handler(lambda c: c.data.startswith("cfg:set:"))
-async def cb_cfg_set(call: types.CallbackQuery):
-    if str(call.from_user.id) != str(ADMIN_ID):
-        return await call.answer("Not allowed.", show_alert=True)
-    _, _, tenant_id, fid, mode = call.data.split(":",4)
-    state = cfg_ensure(tenant_id)
-    # set explicit on/off
-    cur = state["features"].get(fid, False)
-    new = True if mode=="on" else False
-    if cur != new:
-        # emulate toggle until we add dedicated setter
-        from .config_manager import toggle as _toggle
-        # If states differ, ensure ends up desired
-        tmp = _toggle(tenant_id, fid)
-        if tmp["features"].get(fid, False) != new:
-            tmp = _toggle(tenant_id, fid)
-        state = tmp
-    await call.message.edit_reply_markup(reply_markup=_features_onoff_kb(state, tenant_id))
-    await call.answer(f"Set {fid} → {mode.upper()}")
-
-
-
 # === Admin Shield: Assign customer → tenant; Functions On/Off ===
-from aiogram import types
-from aiogram.dispatcher import FSMContext
-from aiogram.dispatcher.filters import Command
-from aiogram.dispatcher.filters.state import State, StatesGroup
-from config_manager import tenants as cfg_tenants, set_tenants as cfg_set_tenants, ensure_config_for as cfg_ensure, set_feature as cfg_set_feature
+from config_manager import (
+    tenants as cfg_tenants,
+    set_tenants as cfg_set_tenants,
+    ensure_config_for as cfg_ensure,
+    set_feature as cfg_set_feature,
+    tenant_for_user as cfg_tenant_for_user,
+)
 
-FEATURES = [("broadcasting","Broadcasting"), ("leveling","Leveling"), ("blackjack","Blackjack"), ("assistants","Assistants")]
+FEATURE_IDS = ["broadcasting", "leveling", "blackjack", "assistants"]
 
 class AssignStates(StatesGroup):
     waiting = State()
 
+
+def _tenant_display_name(tenant: dict) -> str:
+    return tenant.get("name") or tenant.get("id") or "Tenant"
+
+
+def _feature_label(lang: str, feature_id: str) -> str:
+    key = f"feature_name_{feature_id}"
+    return T.get(lang, T["en"]).get(key, feature_id.replace("_", " ").title())
+
+
+def _feature_status(lang: str, enabled: bool) -> str:
+    return T.get(lang, T["en"])[
+        "feature_toggle_enabled" if enabled else "feature_toggle_disabled"
+    ]
+
+
+def _feature_action(lang: str, enabled: bool) -> str:
+    return T.get(lang, T["en"])[
+        "feature_toggle_disable" if enabled else "feature_toggle_enable"
+    ]
+
+
 def _tenants_kb():
     from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
     kb = InlineKeyboardMarkup(row_width=1)
     ts = cfg_tenants()
     if not ts:
-        kb.add(InlineKeyboardButton("No tenants configured", callback_data="cfg:none"))
-    for t in ts:
-        label = f"🧑‍💼 {t.get('name','Unnamed')} ({t.get('id')})"
-        kb.add(InlineKeyboardButton(label, callback_data=f"cfg:tenant:{t.get('id')}"))
+        kb.add(InlineKeyboardButton("📭 No tenants configured", callback_data="cfg:none"))
+        return kb
+
+    for tenant in ts:
+        label = f"🧑‍💼 {_tenant_display_name(tenant)} ({tenant.get('id')})"
+        kb.add(
+            InlineKeyboardButton(label, callback_data=f"cfg:tenant:{tenant.get('id')}")
+        )
     return kb
 
-def _features_onoff_kb(state: dict, tenant_id: str):
+
+def _features_onoff_kb(lang: str, state: dict, tenant_id: str):
     from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
     kb = InlineKeyboardMarkup(row_width=2)
     feats = state.get("features", {})
-    for fid, title in FEATURES:
-        on = feats.get(fid, False)
+    for feature_id in FEATURE_IDS:
+        enabled = feats.get(feature_id, False)
         kb.add(
-            InlineKeyboardButton(f"{title} · {'ON' if on else 'OFF'}", callback_data="cfg:none"),
-            InlineKeyboardButton("Turn Off" if on else "Turn On", callback_data=f"cfg:set:{tenant_id}:{fid}:{'off' if on else 'on'}")
+            InlineKeyboardButton(
+                f"{_feature_label(lang, feature_id)} — {_feature_status(lang, enabled)}",
+                callback_data="cfg:none",
+            ),
+            InlineKeyboardButton(
+                _feature_action(lang, enabled),
+                callback_data=f"cfg:set:{tenant_id}:{feature_id}:{'off' if enabled else 'on'}",
+            ),
         )
     kb.add(InlineKeyboardButton("⬅️ Back", callback_data="cfg:back"))
+    return kb
+
+
+def _user_features_kb(lang: str, state: dict, tenant_id: str):
+    from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+    kb = InlineKeyboardMarkup(row_width=2)
+    feats = state.get("features", {})
+    for feature_id in FEATURE_IDS:
+        enabled = feats.get(feature_id, False)
+        kb.add(
+            InlineKeyboardButton(
+                f"{_feature_label(lang, feature_id)} — {_feature_status(lang, enabled)}",
+                callback_data="cfg:user:noop",
+            ),
+            InlineKeyboardButton(
+                _feature_action(lang, enabled),
+                callback_data=f"cfg:user:set:{tenant_id}:{feature_id}:{'off' if enabled else 'on'}",
+            ),
+        )
+    kb.add(InlineKeyboardButton(T[lang]["feature_toggle_details"], callback_data="cfg:user:info"))
+    kb.add(InlineKeyboardButton(T[lang]["back"], callback_data="back"))
     return kb
 
 @dp.message_handler(Command("admin_shield"))
 async def cmd_admin_shield(message: types.Message):
     if str(message.from_user.id) != str(ADMIN_ID):
         return await message.answer("Admin only.")
-    await message.answer("🛡 Admin Shield\nChoose a tenant or use the panel buttons.", reply_markup=_tenants_kb())
+    await message.answer(
+        "🛡 Admin Shield\nChoose a tenant or use the panel buttons.",
+        reply_markup=_tenants_kb(),
+    )
 
 @dp.callback_query_handler(lambda c: c.data == "admin:assign_customer")
 async def cb_admin_assign(call: types.CallbackQuery, state: FSMContext):
     if str(call.from_user.id) != str(ADMIN_ID):
         return await call.answer("Not allowed.", show_alert=True)
     await state.set_state(AssignStates.waiting.state)
-    await call.message.edit_text("Send mapping:\n<tenant_id> | @username | <config_path>\nExample:\ncustomer1 | @john | C:/path/to/customer1/config.json")
+    await call.message.edit_text(
+        "📋 Send mapping as:\n"
+        "<tenant_id> | <@username or user_id> | <config_path>\n\n"
+        "Example:\ncustomer1 | @john | C:/path/to/customer1/config.json",
+    )
 
 @dp.message_handler(state=AssignStates.waiting)
 async def assign_map(message: types.Message, state: FSMContext):
@@ -1301,42 +1198,137 @@ async def assign_map(message: types.Message, state: FSMContext):
         return
     parts = [p.strip() for p in message.text.split("|")]
     if len(parts) < 2:
-        return await message.answer("Format: tenant_id | @username | optional config_path")
+        return await message.answer(
+            "⚠️ Format: tenant_id | <@username or user_id> | optional config_path"
+        )
+
     tenant_id = parts[0]
-    username = parts[1].lstrip("@")
+    identifier = parts[1]
     cfg_path = parts[2] if len(parts) > 2 else ""
+
+    username = identifier.lstrip("@") if identifier.startswith("@") else ""
+    linked_user_id = None
+
+    if identifier.isdigit():
+        linked_user_id = int(identifier)
+    elif username:
+        record = db.get_user_by_username(username)
+        if record:
+            linked_user_id = record[0]
+
     ts = cfg_tenants()
     found = False
-    for t in ts:
-        if t.get("id")==tenant_id:
-            t["tg_username"] = username
-            if cfg_path: t["config_path"] = cfg_path
+    for tenant in ts:
+        if tenant.get("id") == tenant_id:
+            if username:
+                tenant["tg_username"] = username
+            if linked_user_id is not None:
+                tenant["tg_user_id"] = linked_user_id
+            if cfg_path:
+                tenant["config_path"] = cfg_path
             found = True
             break
+
     if not found:
-        ts.append({"id": tenant_id, "name": tenant_id, "tg_username": username, "config_path": cfg_path})
+        entry = {"id": tenant_id, "name": tenant_id}
+        if username:
+            entry["tg_username"] = username
+        if linked_user_id is not None:
+            entry["tg_user_id"] = linked_user_id
+        if cfg_path:
+            entry["config_path"] = cfg_path
+        ts.append(entry)
+
     cfg_set_tenants(ts)
     await state.finish()
-    await message.answer(f"Mapped @{username} → {tenant_id} ✅")
+
+    who = f"@{username}" if username else (linked_user_id or "unassigned")
+    await message.answer(f"🤝 Linked {who} → {tenant_id} ✅")
 
 @dp.callback_query_handler(lambda c: c.data and c.data.startswith("cfg:tenant:"))
 async def cb_cfg_tenant(call: types.CallbackQuery):
     if str(call.from_user.id) != str(ADMIN_ID):
         return await call.answer("Not allowed.", show_alert=True)
     tenant_id = call.data.split(":", 2)[2]
+    lang = db.get_language(call.from_user.id)
     state = cfg_ensure(tenant_id)
-    await call.message.edit_text(f"⚙️ Functions for {tenant_id}", reply_markup=_features_onoff_kb(state, tenant_id))
+    tenant = next(
+        (t for t in cfg_tenants() if t.get("id") == tenant_id),
+        {"id": tenant_id},
+    )
+    await call.message.edit_text(
+        f"⚙️ {_tenant_display_name(tenant)}",
+        reply_markup=_features_onoff_kb(lang, state, tenant_id),
+    )
 
 @dp.callback_query_handler(lambda c: c.data and c.data.startswith("cfg:set:"))
 async def cb_cfg_set(call: types.CallbackQuery):
     if str(call.from_user.id) != str(ADMIN_ID):
         return await call.answer("Not allowed.", show_alert=True)
-    _, _, tenant_id, fid, mode = call.data.split(":",4)
-    new = True if mode == "on" else False
-    state = cfg_set_feature(tenant_id, fid, new)
-    await call.message.edit_reply_markup(reply_markup=_features_onoff_kb(state, tenant_id))
-    await call.answer(f"{fid} → {'ON' if new else 'OFF'}")
+    _, _, tenant_id, fid, mode = call.data.split(":", 4)
+    new_state = mode == "on"
+    lang = db.get_language(call.from_user.id)
+    state = cfg_set_feature(tenant_id, fid, new_state)
+    await call.message.edit_reply_markup(
+        reply_markup=_features_onoff_kb(lang, state, tenant_id)
+    )
+    await call.answer(
+        f"{_feature_label(lang, fid)} → {_feature_status(lang, new_state)}"
+    )
     
 @dp.callback_query_handler(lambda c: c.data == "cfg:back")
 async def cb_cfg_back(call: types.CallbackQuery):
     await call.message.edit_text("🛡 Admin Shield", reply_markup=_tenants_kb())
+
+
+@dp.callback_query_handler(lambda c: c.data == "cfg:user:info")
+async def cb_cfg_user_info(call: types.CallbackQuery):
+    tenant = cfg_tenant_for_user(call.from_user.id, call.from_user.username)
+    if not tenant:
+        lang = db.get_language(call.from_user.id)
+        return await call.answer(
+            T[lang]["feature_toggle_not_allowed"], show_alert=True
+        )
+
+    lang = db.get_language(call.from_user.id)
+    state = cfg_ensure(tenant["id"])
+    text = T[lang]["functions_toggle_title"].format(
+        tenant=_tenant_display_name(tenant)
+    )
+    history[call.from_user.id].append(
+        (text, _user_features_kb(lang, state, tenant["id"]))
+    )
+    await call.message.edit_text(
+        T[lang]["functions_title"], reply_markup=functions_menu_keyboard(lang)
+    )
+
+
+@dp.callback_query_handler(lambda c: c.data == "cfg:user:noop")
+async def cb_cfg_user_noop(call: types.CallbackQuery):
+    lang = db.get_language(call.from_user.id)
+    await call.answer(T[lang]["feature_toggle_hint"])
+
+
+@dp.callback_query_handler(lambda c: c.data and c.data.startswith("cfg:user:set:"))
+async def cb_cfg_user_set(call: types.CallbackQuery):
+    _, _, tenant_id, fid, mode = call.data.split(":", 4)
+    tenant = cfg_tenant_for_user(call.from_user.id, call.from_user.username)
+
+    if (not tenant or tenant.get("id") != tenant_id) and str(call.from_user.id) != str(ADMIN_ID):
+        lang = db.get_language(call.from_user.id)
+        return await call.answer(
+            T[lang]["feature_toggle_not_allowed"], show_alert=True
+        )
+
+    desired = mode == "on"
+    lang = db.get_language(call.from_user.id)
+    state = cfg_set_feature(tenant_id, fid, desired)
+    await call.message.edit_reply_markup(
+        reply_markup=_user_features_kb(lang, state, tenant_id)
+    )
+    await call.answer(
+        T[lang]["feature_toggle_updated"].format(
+            feature=_feature_label(lang, fid),
+            status=_feature_status(lang, desired),
+        )
+    )

--- a/texts.py
+++ b/texts.py
@@ -82,6 +82,23 @@ T: Dict[str, Dict[str, str]] = {
             "💳 *Payments*\n"
             "Accept secure crypto payments via NOWPayments with automatic confirmations for SOL, USDT-TRC20, and XMR."
         ),
+        "functions_toggle_title": "🧩 *Manage features for {tenant}:*",
+        "functions_toggle_not_assigned": (
+            "🚫 *No bot is linked to your account yet.*\n"
+            "Contact support or your administrator to gain access, or browse feature descriptions below."
+        ),
+        "feature_toggle_details": "ℹ️ Feature descriptions",
+        "feature_toggle_enable": "✅ Enable",
+        "feature_toggle_disable": "⛔ Disable",
+        "feature_toggle_enabled": "🟢 Enabled",
+        "feature_toggle_disabled": "🔴 Disabled",
+        "feature_toggle_hint": "Tap Enable/Disable to switch a feature.",
+        "feature_toggle_not_allowed": "You are not linked to this bot.",
+        "feature_toggle_updated": "{feature} → {status}",
+        "feature_name_broadcasting": "📢 Broadcasting",
+        "feature_name_leveling": "📈 Leveling",
+        "feature_name_blackjack": "🃏 Blackjack",
+        "feature_name_assistants": "🧑‍🤝‍🧑 Assistants",
         "feature_anti_spam": "🛡 Anti-spam filter",
         "feature_anti_spam_desc": (
             "🛡 *Anti-spam filter*\n"
@@ -267,6 +284,23 @@ T: Dict[str, Dict[str, str]] = {
             "💳 *Платежи*\n"
             "Принимайте безопасные криптоплатежи через NOWPayments с авто-подтверждением для SOL, USDT-TRC20 и XMR."
         ),
+        "functions_toggle_title": "🧩 *Управление функциями для {tenant}:*",
+        "functions_toggle_not_assigned": (
+            "🚫 *К вашему аккаунту пока не привязан бот.*\n"
+            "Свяжитесь с поддержкой или администратором, либо изучите описания функций ниже."
+        ),
+        "feature_toggle_details": "ℹ️ Описание функций",
+        "feature_toggle_enable": "✅ Включить",
+        "feature_toggle_disable": "⛔ Выключить",
+        "feature_toggle_enabled": "🟢 Включено",
+        "feature_toggle_disabled": "🔴 Выключено",
+        "feature_toggle_hint": "Нажмите Включить/Выключить, чтобы изменить функцию.",
+        "feature_toggle_not_allowed": "У вас нет доступа к этому боту.",
+        "feature_toggle_updated": "{feature} → {status}",
+        "feature_name_broadcasting": "📢 Рассылки",
+        "feature_name_leveling": "📈 Уровни",
+        "feature_name_blackjack": "🃏 Блэкджек",
+        "feature_name_assistants": "🧑‍🤝‍🧑 Ассистенты",
         "feature_anti_spam": "🛡 Антиспам-фильтр",
         "feature_anti_spam_desc": (
             "🛡 *Антиспам-фильтр*\n"
@@ -452,6 +486,23 @@ T: Dict[str, Dict[str, str]] = {
             "💳 *Mokėjimai*\n"
             "Priimkite saugius kriptomokėjimus per NOWPayments su automatiniu SOL, USDT-TRC20 ir XMR patvirtinimu."
         ),
+        "functions_toggle_title": "🧩 *Valdykite funkcijas botui {tenant}:*",
+        "functions_toggle_not_assigned": (
+            "🚫 *Jūsų paskyrai dar nepriskirtas botas.*\n"
+            "Susisiekite su pagalba ar administratoriumi, o kol kas galite peržiūrėti funkcijų aprašymus žemiau."
+        ),
+        "feature_toggle_details": "ℹ️ Funkcijų aprašymai",
+        "feature_toggle_enable": "✅ Įjungti",
+        "feature_toggle_disable": "⛔ Išjungti",
+        "feature_toggle_enabled": "🟢 Įjungta",
+        "feature_toggle_disabled": "🔴 Išjungta",
+        "feature_toggle_hint": "Paspauskite Įjungti/Išjungti, kad pakeistumėte funkciją.",
+        "feature_toggle_not_allowed": "Neturite prieigos prie šio boto.",
+        "feature_toggle_updated": "{feature} → {status}",
+        "feature_name_broadcasting": "📢 Transliacijos",
+        "feature_name_leveling": "📈 Lygiai",
+        "feature_name_blackjack": "🃏 Blackjack",
+        "feature_name_assistants": "🧑‍🤝‍🧑 Asistentai",
         "feature_anti_spam": "🛡 Anti-spamo filtras",
         "feature_anti_spam_desc": (
             "🛡 *Anti-spamo filtras*\n"


### PR DESCRIPTION
## Summary
- extend the Admin Shield panel so tenant assignments capture Telegram usernames/IDs, add emoji labels, and continue to drive feature toggles through shared helpers
- surface localized feature toggle controls inside Config → Functions for linked customers, reusing shared feature metadata across admin and user panels
- mirror tenant mappings to the external Windows path when updated so remote bots receive config changes alongside per-tenant JSON files

## Testing
- python -m py_compile main.py config_manager.py texts.py keyboards.py

------
https://chatgpt.com/codex/tasks/task_e_68d915bd17dc8332a35c3c81c971464d